### PR TITLE
CircleCI image builds with AGP 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,25 +10,28 @@ jobs:
   build:
     docker:
       - image: cimg/android:2022.03-ndk
+    resource_class: medium
     # https://circleci.com/docs/2.0/env-vars
     environment:
       VCPKG_ROOT: /home/circleci/project/vcpkg
+      VCPKG_FEATURE_FLAGS: "versions,manifests,registries,binarycaching"
+      VCPKG_DEFAULT_BINARY_CACHE: /tmp/vcpkg-cache
     steps:
       - checkout
+      - android/accept-licenses
+      - android/install-ndk:
+          version: 23.1.7779620
       - run: 
           name: "Install APT packages"
           command: |
             sudo apt-get update -y
-            sudo apt-get install -y --fix-missing ninja-build tree curl zip unzip tar rsync
+            sudo apt-get install -y --fix-missing ninja-build pkg-config tree curl zip unzip tar rsync
             sudo apt remove --purge --auto-remove cmake
             wget -q https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz
             tar -x -f cmake-3.23.1-linux-x86_64.tar.gz
             sudo rsync -r ./cmake-3.23.1-linux-x86_64/ /usr/local
             rm -rf cmake-3.23.1-linux-x86_64
             cmake --version
-            ninja --version
-      - android/install-ndk:
-          version: 23.1.7779620
       - run:
           name: "Create local.properties"
           command: |
@@ -40,24 +43,35 @@ jobs:
             echo "export ANDROID_NDK_HOME=${NDK_PATH}" >> $BASH_ENV
             echo "ndk.dir=${NDK_PATH}" >> local.properties
             cat local.properties
+      - restore_cache:
+          key: cch-{{ checksum ".circleci/config.yml" }}
       - run: 
           name: "Setup Vcpkg"
           command: |
+            mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
             git clone --branch=2022.02.23 --depth=1 https://github.com/microsoft/vcpkg
             pushd vcpkg
               ./bootstrap-vcpkg.sh
             popd
-            export VCPKG_ROOT=~/project/vcpkg
             tree -L 1 ${VCPKG_ROOT}
       - run:
           name: "Gradle: wrapper"
           command: gradle wrapper --info
-      - run: 
+      - run:
           name: "Gradle: androidDependencies"
           command: ./gradlew androidDependencies
-      - run: 
+      - save_cache:
+          paths:
+            - ~/.gradle
+            - /tmp/vcpkg-cache
+          key: cch-{{ checksum ".circleci/config.yml" }}
+          when: always
+      - run:
+          name: "Gradle: assembleDebug"
+          command: ./gradlew assembleDebug --info
+      - run:
           name: "Gradle: assemble"
-          command: ./gradlew assemble --info
-      - run: 
+          command: ./gradlew assemble
+      - run:
           name: "Gradle: lint"
           command: ./gradlew lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
     resource_class: medium
     # https://circleci.com/docs/2.0/env-vars
     environment:
-      VCPKG_ROOT: /home/circleci/project/vcpkg
-      VCPKG_FEATURE_FLAGS: "versions,manifests,registries,binarycaching"
+      VCPKG_ROOT: /tmp/vcpkg
+      VCPKG_FEATURE_FLAGS: "registries,binarycaching"
       VCPKG_DEFAULT_BINARY_CACHE: /tmp/vcpkg-cache
     steps:
       - checkout
@@ -33,25 +33,28 @@ jobs:
             rm -rf cmake-3.23.1-linux-x86_64
             cmake --version
       - run:
-          name: "Create local.properties"
+          name: "Fix ANDROID_NDK_HOME"
           command: |
-            touch local.properties
-            tree -L 1 /opt/android/sdk/ndk/23.1.7779620
             tree -L 1 $HOME/android-sdk/ndk/23.1.7779620
             export NDK_PATH=$HOME/android-sdk/ndk/23.1.7779620
             # override the wrong path
             echo "export ANDROID_NDK_HOME=${NDK_PATH}" >> $BASH_ENV
-            echo "ndk.dir=${NDK_PATH}" >> local.properties
-            cat local.properties
+            echo "${ANDROID_NDK_HOME}"
       - restore_cache:
           key: cch-{{ checksum ".circleci/config.yml" }}
       - run: 
           name: "Setup Vcpkg"
           command: |
+            rm vcpkg.json
             mkdir -p ${VCPKG_DEFAULT_BINARY_CACHE}
-            git clone --branch=2022.02.23 --depth=1 https://github.com/microsoft/vcpkg
-            pushd vcpkg
-              ./bootstrap-vcpkg.sh
+            pushd /tmp
+              git clone --branch=2022.02.23 --depth=1 https://github.com/microsoft/vcpkg
+              pushd vcpkg
+                ./bootstrap-vcpkg.sh
+                ./vcpkg install --triplet arm64-android ms-gsl spdlog curl[openssl]
+                ./vcpkg install --triplet arm-android   ms-gsl spdlog curl[openssl]
+                ./vcpkg install --triplet x64-android   ms-gsl spdlog curl[openssl]
+              popd
             popd
             tree -L 1 ${VCPKG_ROOT}
       - run:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
     variables:
       VCPKG_ROOT: "/usr/local/share/vcpkg" # see VCPKG_INSTALLATION_ROOT
       ANDROID_NDK_HOME: "/Users/runner/Library/Android/sdk/ndk/23.1.7779620" # see scripts/azure-pipelines.sh, check $ANDROID_SDK_ROOT
+      SUPPORT_PREFAB: "true"
     steps:
       - checkout: self
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,13 @@ println("Using NDK: ${ndk_toolchain_file}")
 
 apply plugin: "com.android.library"
 android {
-    // buildToolsVersion "32.0.0"
-    compileSdk 32
+    compileSdk 31
     compileOptions {
         // coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    // https://github.com/android/ndk/wiki/Changelog-r22
     ndkVersion "23.1.7779620"
     buildTypes {
         debug {
@@ -81,12 +81,17 @@ android {
     // https://developer.android.com/studio/build/native-dependencies?hl=en
     buildFeatures {
         buildConfig = true
-        prefab true
-        prefabPublishing true
     }
-    prefab {
-        muffin.headers "include"
+    if(System.getenv("SUPPORT_PREFAB") != null){
+        buildFeatures {
+            prefab true
+            prefabPublishing true
+        }
+        prefab {
+            muffin.headers "include"
+        }
     }
+
     packagingOptions {
         // pickFirst "jniLibs/**/*.so"
         exclude "META-INF/LICENSE*" // JUnit 5 will bundle in files

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,17 @@ buildscript {
     }
     dependencies {
         // https://developer.android.com/studio/releases/gradle-plugin
-        classpath("com.android.tools.build:gradle:7.1.2")
+        // see https://github.com/android/ndk/issues/1609
+        //
+        // Linux environment can't find the ninja in android_gradle_build.json
+        // If SUPPORT_PREFAB is not defined, Downgrade the AGP version and build without Prefab...
+        //
+        if(System.getenv("SUPPORT_PREFAB") != null){
+            classpath("com.android.tools.build:gradle:7.1.3")
+        }
+        else {
+            classpath("com.android.tools.build:gradle:7.0.1")
+        }
         // https://github.com/mannodermaus/android-junit5
         classpath("de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0")
     }


### PR DESCRIPTION

### Changes

AGP 7.1 makes a problem in Linux environment.
`android_gradle_build.json` doesn't contain the absolute path to `ninja` build.
For now, use AGP 7.0 in the Circle's Docker image.
Azure Pipelines (Ubuntu, Mac) images will use AGP 7.1 since they works anyway.

Removed `local.properties`.

Add build cache for acceleration. Building libraries with the NDK takes too much time...

### See Also

* https://github.com/android/ndk/issues/1609
