### PR TITLE
Update NDK Camera related code

### DIFF
--- a/muffin/android/java/dev/luncliff/muffin/CameraHandle.java
+++ b/muffin/android/java/dev/luncliff/muffin/CameraHandle.java
@@ -17,7 +17,7 @@ import androidx.annotation.NonNull;
  * @todo capture request with configuration
  * @todo multiple surface request
  */
-public class DeviceHandle {
+public class CameraHandle {
     private long ptr = 0;
 
     /**
@@ -48,7 +48,7 @@ public class DeviceHandle {
      * opened This method is named to support {@link AutoCloseable} in future update
      *
      * @see CameraCaptureSession#close()
-     * @see DeviceHandle#close()
+     * @see CameraHandle#close()
      */
     public native void close();
 
@@ -73,7 +73,7 @@ public class DeviceHandle {
     /**
      * Stop the repeating request
      * 
-     * @see DeviceHandle#startRepeat(Surface)
+     * @see CameraHandle#startRepeat(Surface)
      */
     public native void stopRepeat();
 
@@ -98,7 +98,7 @@ public class DeviceHandle {
     /**
      * Stop(abort) the capture request
      * 
-     * @see DeviceHandle#startCapture(Surface)
+     * @see CameraHandle#startCapture(Surface)
      */
     public native void stopCapture();
 

--- a/muffin/android/java/dev/luncliff/muffin/CameraManager.java
+++ b/muffin/android/java/dev/luncliff/muffin/CameraManager.java
@@ -1,11 +1,11 @@
 package dev.luncliff.muffin;
 
-public class DeviceManager {
+public class CameraManager {
     static {
         Environment.Init();
     }
 
-    private static DeviceHandle[] devices = null;
+    private static CameraHandle[] devices = null;
 
     /**
      * @apiNote Multiple init is safe. Only *first* invocation will take effect
@@ -22,19 +22,19 @@ public class DeviceManager {
     /**
      * @param devices SetDeviceData will provide appropriate internal library id
      */
-    private static native void SetDeviceData(DeviceHandle[] devices);
+    private static native void SetDeviceData(CameraHandle[] devices);
 
     /**
      * @return array of available devices.
-     * @see DeviceHandle
+     * @see CameraHandle
      */
-    public static synchronized DeviceHandle[] GetDevices() {
+    public static synchronized CameraHandle[] GetDevices() {
         if (devices == null) // allocate java objects
         {
             int count = GetDeviceCount();
-            devices = new DeviceHandle[count];
+            devices = new CameraHandle[count];
             for (int i = 0; i < count; ++i)
-                devices[i] = new DeviceHandle();
+                devices[i] = new CameraHandle();
             SetDeviceData(devices);
         }
         return devices;

--- a/muffin/android/java/dev/luncliff/muffin/DeviceHandle.java
+++ b/muffin/android/java/dev/luncliff/muffin/DeviceHandle.java
@@ -4,6 +4,7 @@ import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraDevice;
 import android.os.Handler;
+import android.util.Size;
 import android.view.Surface;
 
 import androidx.annotation.NonNull;
@@ -25,6 +26,14 @@ public class DeviceHandle {
      *         {@link CameraCharacteristics#LENS_FACING_EXTERNAL }
      */
     public native int facing();
+
+    private native int maxWidth();
+
+    private native int maxHeight();
+
+    public Size getSize() {
+        return new Size(maxWidth(), maxHeight());
+    }
 
     /**
      * Open a camera device

--- a/muffin/android/test/dev/luncliff/muffin/SaveImageTest.java
+++ b/muffin/android/test/dev/luncliff/muffin/SaveImageTest.java
@@ -43,10 +43,10 @@ public class SaveImageTest {
             Assertions.assertTrue(outFile.delete());
     }
 
-    static DeviceHandle getAnyCamera() {
-        DeviceManager.Init();
-        Assertions.assertNotEquals(0, DeviceManager.GetDeviceCount());
-        for (DeviceHandle device : DeviceManager.GetDevices()) {
+    static CameraHandle getAnyCamera() {
+        CameraManager.Init();
+        Assertions.assertNotEquals(0, CameraManager.GetDeviceCount());
+        for (CameraHandle device : CameraManager.GetDevices()) {
             return device;
         }
         return null;
@@ -54,7 +54,7 @@ public class SaveImageTest {
 
     @Test
     public void saveToFile() {
-        DeviceHandle camera = getAnyCamera();
+        CameraHandle camera = getAnyCamera();
         Assertions.assertNotNull(camera);
         // camera image reader
         try (ImageReader reader = ImageReader.newInstance(640, 480, ImageFormat.YUV_420_888, 2)) {

--- a/muffin/src/ndk_camera.cpp
+++ b/muffin/src/ndk_camera.cpp
@@ -271,15 +271,13 @@ camera_status_t ndk_camera_manager_t::start_capture(ndk_camera_session_t& info,
     }
     return ACAMERA_OK;
 }
-camera_status_t ndk_camera_manager_t::start_capture(ndk_camera_session_t& info,
+camera_status_t ndk_camera_manager_t::start_capture(ndk_camera_session_t& info, ndk_capture_configuration_t& config,
                                                     ACameraCaptureSession_stateCallbacks& on_state_change,
                                                     ACameraCaptureSession_captureCallbacks& on_capture_event,
-                                                    ANativeWindow* window0, ANativeWindow* window1) noexcept(false) {
+                                                    ANativeWindow* window0) noexcept(false) {
     session_output_container_t outputs{};
     session_output_t output0{window0};
     output0.bind(outputs.handle);
-    session_output_t output1{window1};
-    output1.bind(outputs.handle);
     if (auto status = ACameraDevice_createCaptureSession(info.device, outputs.handle, &on_state_change, &info.session);
         status != ACAMERA_OK) {
         spdlog::error("{}: {}", "ACameraDevice_createCaptureSession", status);
@@ -288,10 +286,10 @@ camera_status_t ndk_camera_manager_t::start_capture(ndk_camera_session_t& info,
     info.repeating = false;
 
     capture_request_t request{info.device, TEMPLATE_STILL_CAPTURE};
+    if (config.handler) config.handler(config.context, request.handle);
     camera_output_target_t target0{window0};
     target0.bind(request.handle);
-    camera_output_target_t target1{window1};
-    target1.bind(request.handle);
+
     if (auto status =
             ACameraCaptureSession_capture(info.session, &on_capture_event, 1, &request.handle, &info.sequence_id);
         status != ACAMERA_OK) {
@@ -318,6 +316,7 @@ camera_status_t ndk_camera_manager_t::start_repeat(ndk_camera_session_t& info,
     capture_request_t request{info.device, TEMPLATE_PREVIEW};
     camera_output_target_t target{window};
     target.bind(request.handle);
+
     if (auto status = ACameraCaptureSession_setRepeatingRequest(info.session, &on_capture_event, 1, &request.handle,
                                                                 &info.sequence_id);
         status != ACAMERA_OK) {
@@ -327,15 +326,13 @@ camera_status_t ndk_camera_manager_t::start_repeat(ndk_camera_session_t& info,
     return ACAMERA_OK;
 }
 
-camera_status_t ndk_camera_manager_t::start_repeat(ndk_camera_session_t& info,
+camera_status_t ndk_camera_manager_t::start_repeat(ndk_camera_session_t& info, ndk_capture_configuration_t& config,
                                                    ACameraCaptureSession_stateCallbacks& on_state_change,
                                                    ACameraCaptureSession_captureCallbacks& on_capture_event,
-                                                   ANativeWindow* window0, ANativeWindow* window1) noexcept(false) {
+                                                   ANativeWindow* window0) noexcept(false) {
     session_output_container_t outputs{};
     session_output_t output0{window0};
     output0.bind(outputs.handle);
-    session_output_t output1{window1};
-    output1.bind(outputs.handle);
     if (auto status = ACameraDevice_createCaptureSession(info.device, outputs.handle, &on_state_change, &info.session);
         status != ACAMERA_OK) {
         spdlog::error("{}: {}", "ACameraDevice_createCaptureSession", status);
@@ -344,10 +341,10 @@ camera_status_t ndk_camera_manager_t::start_repeat(ndk_camera_session_t& info,
     info.repeating = true;
 
     capture_request_t request{info.device, TEMPLATE_PREVIEW};
+    if (config.handler) config.handler(config.context, request.handle);
     camera_output_target_t target0{window0};
     target0.bind(request.handle);
-    camera_output_target_t target1{window1};
-    target1.bind(request.handle);
+
     if (auto status = ACameraCaptureSession_setRepeatingRequest(info.session, &on_capture_event, 1, &request.handle,
                                                                 &info.sequence_id);
         status != ACAMERA_OK) {

--- a/muffin/src/ndk_camera.hpp
+++ b/muffin/src/ndk_camera.hpp
@@ -57,6 +57,7 @@ class ndk_camera_manager_t final {
     ACameraManager* manager = nullptr;
     ACameraIdList* id_list = nullptr;
     std::array<ACameraMetadata*, 4> metadatas{};  // cached metadata
+    ACameraManager_AvailabilityCallbacks callbacks0{};
 
    public:
     ndk_camera_manager_t() noexcept(false);
@@ -66,6 +67,13 @@ class ndk_camera_manager_t final {
     ndk_camera_manager_t& operator=(const ndk_camera_manager_t&) = delete;
     ndk_camera_manager_t& operator=(ndk_camera_manager_t&&) = delete;
 
+   private:
+    static void camera_available(ndk_camera_manager_t& self, const char* id);
+    static void camera_unavailable(ndk_camera_manager_t& self, const char* id);
+    void on_camera_available(const char* id);
+    void on_camera_unavailable(const char* id);
+
+   public:
     uint32_t count() const noexcept;
 
     camera_status_t open_device(uint32_t idx, ndk_camera_session_t& info,
@@ -92,6 +100,7 @@ class ndk_camera_manager_t final {
                                  ANativeWindow* window) noexcept(false);
     void close_session(ndk_camera_session_t& info) noexcept(false);
 
+    uint32_t get_index(const char* id) const noexcept;
     uint32_t get_index(ACameraDevice* device) const noexcept;
     ACameraMetadata* get_metadata(ACameraDevice* device) const noexcept;
 };

--- a/muffin/src/ndk_camera.hpp
+++ b/muffin/src/ndk_camera.hpp
@@ -32,12 +32,18 @@ ndk_camera_error_category_t& get_ndk_camera_errors() noexcept;
 /**
  * @see https://developer.android.com/ndk/reference/group/camera
  */
-struct ndk_camera_session_t {
+struct ndk_camera_session_t final {
     ACameraDevice* device = nullptr;
     ACameraCaptureSession* session = nullptr;
     uint16_t index = UINT16_MAX;
     bool repeating = false;                      // flag to indicate if the session is repeating
     int sequence_id = CAPTURE_SEQUENCE_ID_NONE;  // sequence ID from capture session
+};
+
+struct ndk_capture_configuration_t final {
+    using handler_t = void (*)(void*, ACaptureRequest*);
+    void* context;
+    handler_t handler;
 };
 
 /**
@@ -72,16 +78,18 @@ class ndk_camera_manager_t final {
     camera_status_t start_capture(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
                                   ACameraCaptureSession_captureCallbacks& on_capture_event,  //
                                   ANativeWindow* window) noexcept(false);
-    camera_status_t start_capture(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
+    camera_status_t start_capture(ndk_camera_session_t& info, ndk_capture_configuration_t& config,
+                                  ACameraCaptureSession_stateCallbacks& on_state_change,
                                   ACameraCaptureSession_captureCallbacks& on_capture_event,  //
-                                  ANativeWindow* window0, ANativeWindow* window1) noexcept(false);
+                                  ANativeWindow* window) noexcept(false);
     /// @see https://developer.android.com/ndk/reference/group/camera#acameradevice_createcapturesession
     camera_status_t start_repeat(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
                                  ACameraCaptureSession_captureCallbacks& on_capture_event,  //
                                  ANativeWindow* window) noexcept(false);
-    camera_status_t start_repeat(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
+    camera_status_t start_repeat(ndk_camera_session_t& info, ndk_capture_configuration_t& config,
+                                 ACameraCaptureSession_stateCallbacks& on_state_change,
                                  ACameraCaptureSession_captureCallbacks& on_capture_event,  //
-                                 ANativeWindow* window0, ANativeWindow* window1) noexcept(false);
+                                 ANativeWindow* window) noexcept(false);
     void close_session(ndk_camera_session_t& info) noexcept(false);
 
     uint32_t get_index(ACameraDevice* device) const noexcept;

--- a/muffin/src/ndk_camera.hpp
+++ b/muffin/src/ndk_camera.hpp
@@ -68,12 +68,18 @@ class ndk_camera_manager_t final {
     /// @note The function doesn't free metadata
     void close_device(ndk_camera_session_t& info) noexcept;
 
-    camera_status_t start_capture(ndk_camera_session_t& info, ANativeWindow* window,
-                                  ACameraCaptureSession_stateCallbacks& on_state_change,
-                                  ACameraCaptureSession_captureCallbacks& on_capture_event) noexcept(false);
-    camera_status_t start_repeat(ndk_camera_session_t& info, ANativeWindow* window,
-                                 ACameraCaptureSession_stateCallbacks& on_state_change,
-                                 ACameraCaptureSession_captureCallbacks& on_capture_event) noexcept(false);
+    camera_status_t start_capture(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
+                                  ACameraCaptureSession_captureCallbacks& on_capture_event,  //
+                                  ANativeWindow* window) noexcept(false);
+    camera_status_t start_capture(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
+                                  ACameraCaptureSession_captureCallbacks& on_capture_event,  //
+                                  ANativeWindow* window0, ANativeWindow* window1) noexcept(false);
+    camera_status_t start_repeat(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
+                                 ACameraCaptureSession_captureCallbacks& on_capture_event,  //
+                                 ANativeWindow* window) noexcept(false);
+    camera_status_t start_repeat(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
+                                 ACameraCaptureSession_captureCallbacks& on_capture_event,  //
+                                 ANativeWindow* window0, ANativeWindow* window1) noexcept(false);
     void close_session(ndk_camera_session_t& info) noexcept(false);
 
     uint32_t get_index(ACameraDevice* device) const noexcept;

--- a/muffin/src/ndk_camera.hpp
+++ b/muffin/src/ndk_camera.hpp
@@ -68,12 +68,14 @@ class ndk_camera_manager_t final {
     /// @note The function doesn't free metadata
     void close_device(ndk_camera_session_t& info) noexcept;
 
+    /// @see https://developer.android.com/ndk/reference/group/camera#acameradevice_createcapturesession
     camera_status_t start_capture(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
                                   ACameraCaptureSession_captureCallbacks& on_capture_event,  //
                                   ANativeWindow* window) noexcept(false);
     camera_status_t start_capture(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
                                   ACameraCaptureSession_captureCallbacks& on_capture_event,  //
                                   ANativeWindow* window0, ANativeWindow* window1) noexcept(false);
+    /// @see https://developer.android.com/ndk/reference/group/camera#acameradevice_createcapturesession
     camera_status_t start_repeat(ndk_camera_session_t& info, ACameraCaptureSession_stateCallbacks& on_state_change,
                                  ACameraCaptureSession_captureCallbacks& on_capture_event,  //
                                  ANativeWindow* window) noexcept(false);

--- a/muffin/src/ndk_camera_jni.cpp
+++ b/muffin/src/ndk_camera_jni.cpp
@@ -81,13 +81,13 @@ using native_window_ptr = std::unique_ptr<ANativeWindow, void (*)(ANativeWindow*
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_dev_luncliff_muffin_DeviceManager_Init(JNIEnv* env, jclass clazz) {
+JNIEXPORT void JNICALL Java_dev_luncliff_muffin_CameraManager_Init(JNIEnv* env, jclass clazz) {
     static std::once_flag flag{};
     return std::call_once(flag, init_camera_manager, env, clazz);
 }
 
 JNIEXPORT
-jint Java_dev_luncliff_muffin_DeviceManager_GetDeviceCount(JNIEnv* env, jclass) noexcept {
+jint Java_dev_luncliff_muffin_CameraManager_GetDeviceCount(JNIEnv* env, jclass) noexcept {
     try {
         return static_cast<jint>(camera_manager->count());
     } catch (const std::exception& ex) {
@@ -98,7 +98,7 @@ jint Java_dev_luncliff_muffin_DeviceManager_GetDeviceCount(JNIEnv* env, jclass) 
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceManager_SetDeviceData(JNIEnv* env, jclass, jobjectArray devices) noexcept {
+void Java_dev_luncliff_muffin_CameraManager_SetDeviceData(JNIEnv* env, jclass, jobjectArray devices) noexcept {
     // env->FindClass("dev/luncliff/muffin/DeviceHandle");
     int num_devices = static_cast<int>(camera_manager->count());
     // https://developer.android.com/ndk/reference/group/camera
@@ -111,7 +111,7 @@ void Java_dev_luncliff_muffin_DeviceManager_SetDeviceData(JNIEnv* env, jclass, j
 }
 
 JNIEXPORT
-int Java_dev_luncliff_muffin_DeviceHandle_facing(JNIEnv* env, jobject self) noexcept {
+int Java_dev_luncliff_muffin_CameraHandle_facing(JNIEnv* env, jobject self) noexcept {
     ndk_camera_session_t* ptr = cast_device_handle(env, self);
     ACameraMetadata* metadata = camera_manager->get_metadata(ptr->device);
     if (metadata == nullptr) return ACAMERA_LENS_FACING_EXTERNAL;
@@ -119,7 +119,7 @@ int Java_dev_luncliff_muffin_DeviceHandle_facing(JNIEnv* env, jobject self) noex
 }
 
 JNIEXPORT
-int Java_dev_luncliff_muffin_DeviceHandle_maxWidth(JNIEnv* env, jobject self) noexcept {
+int Java_dev_luncliff_muffin_CameraHandle_maxWidth(JNIEnv* env, jobject self) noexcept {
     ndk_camera_session_t* ptr = cast_device_handle(env, self);
     ACameraMetadata* metadata = camera_manager->get_metadata(ptr->device);
     if (metadata == nullptr) return 0;
@@ -128,7 +128,7 @@ int Java_dev_luncliff_muffin_DeviceHandle_maxWidth(JNIEnv* env, jobject self) no
 }
 
 JNIEXPORT
-int Java_dev_luncliff_muffin_DeviceHandle_maxHeight(JNIEnv* env, jobject self) noexcept {
+int Java_dev_luncliff_muffin_CameraHandle_maxHeight(JNIEnv* env, jobject self) noexcept {
     ndk_camera_session_t* ptr = cast_device_handle(env, self);
     ACameraMetadata* metadata = camera_manager->get_metadata(ptr->device);
     if (metadata == nullptr) return 0;
@@ -137,7 +137,7 @@ int Java_dev_luncliff_muffin_DeviceHandle_maxHeight(JNIEnv* env, jobject self) n
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceHandle_open(JNIEnv* env, jobject self) noexcept {
+void Java_dev_luncliff_muffin_CameraHandle_open(JNIEnv* env, jobject self) noexcept {
     try {
         ndk_camera_session_t* ptr = cast_device_handle(env, self);
 
@@ -155,14 +155,14 @@ void Java_dev_luncliff_muffin_DeviceHandle_open(JNIEnv* env, jobject self) noexc
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceHandle_close(JNIEnv* env, jobject self) noexcept {
+void Java_dev_luncliff_muffin_CameraHandle_close(JNIEnv* env, jobject self) noexcept {
     ndk_camera_session_t* ptr = cast_device_handle(env, self);
     if (ptr == nullptr) return;
     camera_manager->close_device(*ptr);
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceHandle_startRepeat(JNIEnv* env, jobject self, jobject surface) noexcept {
+void Java_dev_luncliff_muffin_CameraHandle_startRepeat(JNIEnv* env, jobject self, jobject surface) noexcept {
     auto ptr = cast_device_handle(env, self);
 
     // `ANativeWindow_fromSurface` acquires a reference
@@ -203,7 +203,7 @@ void Java_dev_luncliff_muffin_DeviceHandle_startRepeat(JNIEnv* env, jobject self
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceHandle_stopRepeat(JNIEnv* env, jobject self) noexcept {
+void Java_dev_luncliff_muffin_CameraHandle_stopRepeat(JNIEnv* env, jobject self) noexcept {
     try {
         auto ptr = cast_device_handle(env, self);
         camera_manager->close_session(*ptr);
@@ -214,7 +214,7 @@ void Java_dev_luncliff_muffin_DeviceHandle_stopRepeat(JNIEnv* env, jobject self)
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceHandle_startCapture(JNIEnv* env, jobject self, jobject surface) noexcept {
+void Java_dev_luncliff_muffin_CameraHandle_startCapture(JNIEnv* env, jobject self, jobject surface) noexcept {
     auto ptr = cast_device_handle(env, self);
 
     // `ANativeWindow_fromSurface` acquires a reference
@@ -255,7 +255,7 @@ void Java_dev_luncliff_muffin_DeviceHandle_startCapture(JNIEnv* env, jobject sel
 }
 
 JNIEXPORT
-void Java_dev_luncliff_muffin_DeviceHandle_stopCapture(JNIEnv* env, jobject self) noexcept {
+void Java_dev_luncliff_muffin_CameraHandle_stopCapture(JNIEnv* env, jobject self) noexcept {
     try {
         auto ptr = cast_device_handle(env, self);
         camera_manager->close_session(*ptr);

--- a/sample/src/main/java/dev/luncliff/sample/MainActivity.java
+++ b/sample/src/main/java/dev/luncliff/sample/MainActivity.java
@@ -23,7 +23,7 @@ import dev.luncliff.muffin.DeviceManager;
 import dev.luncliff.sample.databinding.ActivityMainBinding;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener, SurfaceHolder.Callback2 {
-    static { 
+    static {
         System.loadLibrary("sample");
     }
     static int windowFlags = WindowManager.LayoutParams.FLAG_FULLSCREEN
@@ -34,10 +34,11 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private SurfaceHolder holder0;
     private DeviceHandle camera;
 
-    private void requestPermissions(){
+    private void requestPermissions() {
         Activity activity = this;
-        if(ActivityCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED)
-            ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.CAMERA}, 0xBEEF);
+        if (ActivityCompat.checkSelfPermission(activity,
+                Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED)
+            ActivityCompat.requestPermissions(activity, new String[] { Manifest.permission.CAMERA }, 0xBEEF);
     }
 
     @Override
@@ -53,7 +54,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         holder0 = view0.getHolder();
         holder0.addCallback(this);
         holder0.setFormat(ImageFormat.YUV_420_888); // Use `PixelFormat.RGBX_8888` for Graphics output
-        holder0.setFixedSize(1280, 720);
+        holder0.setFixedSize(1920, 1080);
     }
 
     @Override
@@ -70,9 +71,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         Log.i("MainActivity", "onPause");
         camera.close();
         // This won't happen. We may try more detailed control but not here...
-        if(view0.getHolder() != holder0){
-             holder0.removeCallback(this);
-             view0.setVisibility(View.GONE);
+        if (view0.getHolder() != holder0) {
+            holder0.removeCallback(this);
+            view0.setVisibility(View.GONE);
         }
     }
 

--- a/sample/src/main/java/dev/luncliff/sample/MainActivity.java
+++ b/sample/src/main/java/dev/luncliff/sample/MainActivity.java
@@ -9,17 +9,15 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.graphics.ImageFormat;
-import android.graphics.PixelFormat;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.SurfaceHolder;
-import android.view.Surface;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import dev.luncliff.AutoFitSurfaceView;
-import dev.luncliff.muffin.DeviceHandle;
-import dev.luncliff.muffin.DeviceManager;
+import dev.luncliff.muffin.CameraHandle;
+import dev.luncliff.muffin.CameraManager;
 import dev.luncliff.sample.databinding.ActivityMainBinding;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener, SurfaceHolder.Callback2 {
@@ -32,7 +30,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private InputMethodManager inputs;
     private AutoFitSurfaceView view0;
     private SurfaceHolder holder0;
-    private DeviceHandle camera;
+    private CameraHandle camera;
 
     private void requestPermissions() {
         Activity activity = this;
@@ -62,7 +60,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         super.onResume();
         Log.i("MainActivity", "onResume");
         requestPermissions();
-        camera = DeviceManager.GetDevices()[0];
+        camera = CameraManager.GetDevices()[0];
     }
 
     @Override

--- a/sample/src/main/java/dev/luncliff/sample/MuffinApp.java
+++ b/sample/src/main/java/dev/luncliff/sample/MuffinApp.java
@@ -1,7 +1,6 @@
 package dev.luncliff.sample;
 
 import android.app.Application;
-import android.hardware.camera2.CameraManager;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -11,7 +10,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import dev.luncliff.muffin.DeviceManager;
+import dev.luncliff.muffin.CameraManager;
 
 public class MuffinApp extends Application {
     private final HandlerThread thread0 = new HandlerThread("muffin-thread-0");
@@ -38,8 +37,8 @@ public class MuffinApp extends Application {
     public void onCreate() {
         super.onCreate();
         setupHandler();
-        DeviceManager.Init();
-        Log.i("App", String.format("Camera Count: %d", DeviceManager.GetDeviceCount()));
+        CameraManager.Init();
+        Log.i("App", String.format("Camera Count: %d", CameraManager.GetDeviceCount()));
     }
 
     @Override


### PR DESCRIPTION
### Changes

Rename some types.

* Multiple instance of `ANativeWindow*` can be used in `start_repeat` and `start_capture`
* Register callbacks for camera availability. See [`ACameraManager_registerAvailabilityCallback`](https://developer.android.google.cn/ndk/reference/group/camera#acameramanager_registeravailabilitycallback)
* More helpful messages for [`ACameraDevice_ErrorStateCallback`](https://developer.android.google.cn/ndk/reference/group/camera#acameradevice_errorstatecallback)
